### PR TITLE
Fix typo: The first Intel math coprocessor was the 8087, not the 80287

### DIFF
--- a/booksources/chapters/arithmetic.tex
+++ b/booksources/chapters/arithmetic.tex
@@ -2275,7 +2275,7 @@ processors could have a whole range of precisions. In practice,
 only single and double precision as defined have been used.
 However, one instance of \indextermdef{extended precision} still survives:
 Intel processors have 80-bit registers for storing intermediate results.
-(This goes back to the \indextermbus{Intel}{80287 co-processor}.)
+(This goes back to the \indextermbus{Intel}{8087 co-processor}.)
 This strategy makes sense in \indexac{FMA} instructions, 
 and in the accumulation of inner products.
 

--- a/booksources/chapters/parallel.tex
+++ b/booksources/chapters/parallel.tex
@@ -2367,7 +2367,7 @@ efficiency. Thus, the idea of incorporating a \emph{co-processor}
 attached to the \indexterm{host process}
 has been explored many times. For instance, Intel's 8086 chip, which
 powered the first generation of IBM PCs, could have a numerical
-co-processor, the 80287, added to it. This processor was very
+co-processor, the 8087, added to it. This processor was very
 efficient at transcendental functions and it also incorporated
 \ac{SIMD} technology. Using separate functionality for graphics has also
 been popular, leading to the \indexac{SSE} instructions for the x86 processor,


### PR DESCRIPTION
@VictorEijkhout , I have taken occasional looks at your textbook as it has evolved over the years and was looking again today. It has turned into something really fantastic! Thank you so much for putting this together and out there on the web for everyone to read.

While perusing today, I noticed what I believe is a typo. You give the number of the original Intel math coprocessor as "80287"; however, the original math coprocessor was the 8087, which paired with the 8086 CPU. Later, when the 80286 CPU was introduced, the accompanying coprocessor was the 80287. It is the 8087 that introduced the extended 80-bit floating point representation.